### PR TITLE
migrateファイルに存在しないテーブル定義が入っていたので削除

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,16 +25,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_104826) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.integer "micropost_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["micropost_id"], name: "index_likes_on_micropost_id"
-    t.index ["user_id", "micropost_id"], name: "index_likes_on_user_id_and_micropost_id", unique: true
-    t.index ["user_id"], name: "index_likes_on_user_id"
-  end
-
   create_table "topcs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.string "description"
@@ -57,7 +47,6 @@ ActiveRecord::Schema.define(version: 2020_02_24_104826) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
-    t.string "image"
   end
 
 end


### PR DESCRIPTION
https://github.com/27-Inoue-Yuki/pictgram/pull/9#discussion_r387244525 の話。
無用な差分を削除する。